### PR TITLE
Bad itoa64 Parameter and MPPA-256 GLIBC Issues

### DIFF
--- a/build/mppa256/makefile
+++ b/build/mppa256/makefile
@@ -37,6 +37,7 @@ export AR := $(TOOLCHAIN_DIR)/bin/k1-ar
 export CFLAGS := -D__mppa256__
 export CFLAGS += -mos=bare -march=k1b -mboard=developer
 export CFLAGS += -D __HAS_HW_DIVISION=1 -D__HAS_HW_MULTIPLICATION=1
+export CFLAGS += -D __GLIBC_BUG__
 
 #===============================================================================
 

--- a/makefile
+++ b/makefile
@@ -62,7 +62,7 @@ include $(MAKEDIR)/makefile
 #===============================================================================
 
 export CFLAGS += -std=c99 -fno-builtin
-export CFLAGS += -ansi -pedantic-errors
+export CFLAGS += -pedantic-errors
 export CFLAGS += -Wall -Wextra -Werror -Wa,--warn
 export CFLAGS += -Winit-self -Wswitch-default -Wfloat-equal
 export CFLAGS += -Wundef -Wshadow -Wuninitialized -Wlogical-op

--- a/src/vsprintf.c
+++ b/src/vsprintf.c
@@ -110,6 +110,8 @@ static int itoa(char *str, unsigned num, int base)
 	return(p - str);
 }
 
+#ifndef __qemu_riscv32__
+
 /**
  * @brief Converts an 64 bit integer to a string.
  *
@@ -196,6 +198,8 @@ static int itoa64(char *str, unsigned long long num, int base)
 	return(p - str);
 }
 
+#endif /* !qemu_riscv32 */
+
 /**
  * @brief Writes formatted data from variable argument list to a string.
  *
@@ -233,6 +237,9 @@ int __vsprintf(char *str, const char *fmt, va_list args)
 				case 'x':
 					str += itoa(str, va_arg(args, unsigned int), 'x');
 					break;
+
+#ifndef __qemu_riscv32__
+
 				case 'l':
 					if(*(fmt + 1) == 'x')
 					{
@@ -242,6 +249,8 @@ int __vsprintf(char *str, const char *fmt, va_list args)
 					else
 						str += itoa64(str, va_arg(args, unsigned long long int), 'l');
 					break;
+
+#endif
 
 				/* String. */
                 case 's':

--- a/src/vsprintf.c
+++ b/src/vsprintf.c
@@ -108,7 +108,7 @@ static int itoa(char *str, unsigned num, int base)
  *
  * @returns The length of the output string.
  */
-static int itoa64(char *str, unsigned long num, int base)
+static int itoa64(char *str, unsigned long long num, int base)
 {
 	char *b = str;
 	char *p, *p1, *p2;
@@ -130,7 +130,7 @@ static int itoa64(char *str, unsigned long num, int base)
 	/* Convert number. */
 	do
 	{
-		unsigned long remainder = num % divisor;
+		unsigned long long remainder = num % divisor;
 
 		*p++ = (remainder < 10) ?
 			remainder + '0' : remainder + 'a' - 10;
@@ -146,7 +146,7 @@ static int itoa64(char *str, unsigned long num, int base)
 	/* Convert number. */
 	do
 	{
-		unsigned long remainder = num & 0xf;
+		unsigned long long remainder = num & 0xf;
 
 		*p++ = (remainder < 10) ?
 			remainder + '0' : remainder + 'a' - 10;
@@ -214,11 +214,11 @@ int __vsprintf(char *str, const char *fmt, va_list args)
 				case 'l':
 					if(*(fmt + 1) == 'x')
 					{
-						str += itoa64(str, va_arg(args, unsigned long int), 'h');
+						str += itoa64(str, va_arg(args, unsigned long long int), 'h');
 						++fmt;
 					}
 					else
-						str += itoa64(str, va_arg(args, unsigned long int), 'l');
+						str += itoa64(str, va_arg(args, unsigned long long int), 'l');
 					break;
 
 				/* String. */

--- a/src/vsprintf.c
+++ b/src/vsprintf.c
@@ -56,9 +56,20 @@ static int itoa(char *str, unsigned num, int base)
 	{
 		unsigned remainder = num % divisor;
 
+#ifdef __GLIBC_BUG__
+		remainder = (divisor == 10 ? (num % 10) : (num % 16));
+#else
+		remainder = num % divisor;
+#endif
+
 		*p++ = (remainder < 10) ?
 			remainder + '0' : remainder + 'a' - 10;
+
+#ifdef __GLIBC_BUG__
+	} while ((divisor == 10 ? (num /= 10) : (num /= 16)));
+#else
 	} while (num /= divisor);
+#endif
 
 #else
 
@@ -130,11 +141,22 @@ static int itoa64(char *str, unsigned long long num, int base)
 	/* Convert number. */
 	do
 	{
-		unsigned long long remainder = num % divisor;
+		unsigned long long remainder;
+
+#ifdef __GLIBC_BUG__
+		remainder = (divisor == 10 ? (num % 10) : (num % 16));
+#else
+		remainder = num % divisor;
+#endif
 
 		*p++ = (remainder < 10) ?
 			remainder + '0' : remainder + 'a' - 10;
+
+#ifdef __GLIBC_BUG__
+	} while ((divisor == 10 ? (num /= 10) : (num /= 16)));
+#else
 	} while (num /= divisor);
+#endif
 
 #else
 


### PR DESCRIPTION
# Description
- **Incorrect `itoa64` parameter:** When we print a 64-bit variable on MPPA-256, `itoa64` reads 32-bit variable from stack. So, I change the `unsigned long` to `unsigned long long` to correct the 64-bit read.
- **MPPA-256 GLIBC issues:** I found that module and division operations using variable-saved operands generated the use of GLIBC functions (`__modsi` and `__udivsi3`). However, when using constants on the right side of the operators, the generated code used MPPA-256 processor instructions. Thus, the bug was circumvented by adding a flag that uses code with constants in the `itoa` and `itoa64` functions.