### PR TITLE
No Initialization with Module Operation in itoa

### DIFF
--- a/src/vsprintf.c
+++ b/src/vsprintf.c
@@ -54,7 +54,7 @@ static int itoa(char *str, unsigned num, int base)
 	/* Convert number. */
 	do
 	{
-		unsigned remainder = num % divisor;
+		unsigned remainder;
 
 #ifdef __GLIBC_BUG__
 		remainder = (divisor == 10 ? (num % 10) : (num % 16));


### PR DESCRIPTION
It was forgotten in the last PR to remove the initialization of the variable in `itoa` that used module operation. In this PR, I fix this bug.