### PR TITLE
[mppa256] Power of Two Module and Division Operands

### DIFF
--- a/build/mppa256/makefile.cflags
+++ b/build/mppa256/makefile.cflags
@@ -176,7 +176,7 @@ ifeq ($(RELEASE), true)
 	export CFLAGS += -fisolate-erroneous-paths-attribute
 	export CFLAGS += -fivopts
 	export CFLAGS += -flifetime-dse
-	export CFLAGS += -flive-range-shrinkage
+	# export CFLAGS += -flive-range-shrinkage                        # === FREEZE EXECUTION       ===
 	# export CFLAGS += -floop-nest-optimize
 	export CFLAGS += -fmath-errno
 	export CFLAGS += -fmerge-all-constants
@@ -201,7 +201,7 @@ ifeq ($(RELEASE), true)
 	export CFLAGS += -fsigned-zeros
 	export CFLAGS += -fsingle-precision-constant
 	export CFLAGS += -fsplit-ivs-in-unroller
-	export CFLAGS += -ftoplevel-reorder
+	# export CFLAGS += -ftoplevel-reorder                            # === FREEZE EXECUTION       ===
 	export CFLAGS += -ftrapping-math
 	export CFLAGS += -ftrapv
 	export CFLAGS += -ftree-coalesce-inlined-vars

--- a/include/nanvix/barelib.h
+++ b/include/nanvix/barelib.h
@@ -427,6 +427,26 @@
 	 */
 	extern int __mult(int a, int b);
 
+	/**
+	 * @brief Compute @p a % @p b where @p b must be a power-of-2 (1, 2, 4, 8, ...).
+	 *
+	 * @param n Operator
+	 * @param m Module factor.
+	 *
+	 * @returns @p a % @p b.
+	 */
+	extern int __mod_pw2(int a, int b);
+
+	/**
+	 * @brief Compute @p a / @p b where @p b must be a power-of-2 (1, 2, 4, 8, ...).
+	 *
+	 * @param n Operator
+	 * @param m Dividend factor.
+	 *
+	 * @returns @p a / @p b.
+	 */
+	extern int __div_pw2(int a, int b);
+
 /**@}*/
 
 #endif /* NANVIX_BARELIB_H_ */

--- a/src/div_pw2.c
+++ b/src/div_pw2.c
@@ -1,0 +1,46 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2011-2020 The Maintainers of Nanvix
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * @brief Compute @p a / @p b where @p b must be a power-of-2 (1, 2, 4, 8, ...).
+ *
+ * @param n Operator
+ * @param m Divide factor.
+ *
+ * @returns @p a / @p b.
+ */
+int __div_pw2(int a, int b)
+{
+	int p;
+
+	if (b == 0)
+		return (-1);
+
+	p = 0;
+	while (b >>= 1)
+		p++;
+
+	return (a >> p);
+}
+

--- a/src/mod_pw2.c
+++ b/src/mod_pw2.c
@@ -1,0 +1,37 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2011-2020 The Maintainers of Nanvix
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * @brief Compute @p a % @p b where @p b must be a power-of-2 (1, 2, 4, 8, ...).
+ *
+ * @param n Operator
+ * @param m Module factor.
+ *
+ * @returns @p a % @p b.
+ */
+int __mod_pw2(int a, int b)
+{
+	return (a & (b - 1));
+}
+


### PR DESCRIPTION
In this PR, I add two functions that help in avoiding use % and / operations when involved right operands of power-of-two in the MPPA-256.

I also comment some bugged flags in the MPPA-256.